### PR TITLE
Make the knot configuration file a variable

### DIFF
--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -28,6 +28,9 @@ galaxy_info:
         - 7
         - 8
     - name: ArchLinux
+    - name: FreeBSD
+      versions:
+        - 13.0
 
   galaxy_tags:
     - dns

--- a/tasks/configure.yaml
+++ b/tasks/configure.yaml
@@ -3,7 +3,7 @@
 - name: 'update configuration'
   template:
     src: 'etc/knot/knot.conf.j2'
-    dest: '/etc/knot/knot.conf'
+    dest: "{{ knot_config_file }}"
     owner: 'root'
     group: "{{ knot_group }}"
     mode: "0o640"

--- a/tasks/install.yaml
+++ b/tasks/install.yaml
@@ -1,8 +1,16 @@
 ---
 
-- name: installing knot-dns
+- name: installing dependencies
   package:
-    name: "knot"
+    name: "{{ item }}"
     state: "present"
+  with_items: "{{ knot_dependencies }}"
+  when: knot_dependencies
+
+- name: installing knot package(s)
+  package:
+    name: "{{ item }}"
+    state: "present"
+  with_items: "{{ knot_packages }}"
 
 ...

--- a/tasks/prepare.yaml
+++ b/tasks/prepare.yaml
@@ -11,7 +11,7 @@
         - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yaml"
         # eg. debian / ubuntu / centos / oraclelinux
         - "{{ ansible_distribution | lower }}.yaml"
-        # eg. redhat / debian / archlinux
+        # eg. redhat / debian / archlinux / freebsd
         - "{{ ansible_os_family | lower }}.yaml"
         # artixlinux
         - "{{ ansible_os_family | lower | replace(' ', '') }}.yaml"

--- a/vars/freebsd.yaml
+++ b/vars/freebsd.yaml
@@ -1,0 +1,8 @@
+---
+knot_packages:
+  - knot3
+
+knot_config_file: /usr/local/etc/knot/knot.conf
+knot_rundir: /var/run/knot
+knot_knotc: /usr/local/sbin/knotc
+knot_database: /var/db/knot

--- a/vars/main.yaml
+++ b/vars/main.yaml
@@ -7,6 +7,7 @@ knot_user: knot
 knot_group: knot
 
 knot_database: /var/lib/knot
+knot_config_file: /etc/knot/knot.conf
 
 knot_knotc: /usr/sbin/knotc
 


### PR DESCRIPTION
This enables support for non-standard configuration file paths, which is used in FreeBSD. (and probably other systems as well)

For backwards compatibility the default value is set to the old explicitly set value (/etc/knot/knot.conf)